### PR TITLE
Feat[#6] register 회원가입 페이지 구현

### DIFF
--- a/final/Frontend/final-front/src/router/index.js
+++ b/final/Frontend/final-front/src/router/index.js
@@ -4,6 +4,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 // 홈 페이지는 즉시 로드
 import Home from '../views/HomeView.vue'
 import Login from '../views/LoginView.vue'
+import Register from '../views/RegisterView.vue'
 
 const routes = [
   {
@@ -15,6 +16,11 @@ const routes = [
     path: '/login',
     name: 'Login',
     component: Login
+  }
+  ,{
+    path: '/register',
+    name: 'Register',
+    component: Register
   }
   // ,{
   //   path: '/attractions',

--- a/final/Frontend/final-front/src/views/RegisterView.vue
+++ b/final/Frontend/final-front/src/views/RegisterView.vue
@@ -4,6 +4,43 @@
       <h2>회원가입</h2>
       <form @submit.prevent="handleRegister" class="register-form">
         <div class="form-group">
+          <label for="email">이메일 (아이디)</label>
+          <input
+            type="email"
+            id="email"
+            v-model="registerForm.email"
+            required
+            placeholder="이메일을 입력하세요"
+          />
+        </div>
+
+        
+        <div class="form-group">
+            <label for="password">비밀번호</label>
+            <input
+            type="password"
+            id="password"
+            v-model="registerForm.password"
+            required
+            placeholder="비밀번호를 입력하세요"
+            />
+        </div>
+        
+        <div class="form-group">
+            <label for="passwordConfirm">비밀번호 확인</label>
+            <input
+            type="password"
+            id="passwordConfirm"
+            v-model="passwordConfirm"
+            required
+            placeholder="비밀번호를 다시 입력하세요"
+            />
+            <span class="password-match" :class="{ 'not-match': !isPasswordMatch && passwordConfirm }">
+                {{ passwordMatchMessage }}
+            </span>
+        </div>
+        
+        <div class="form-group">
           <label for="name">이름</label>
           <input
             type="text"
@@ -15,44 +52,8 @@
         </div>
         
         <div class="form-group">
-          <label for="password">비밀번호</label>
-          <input
-            type="password"
-            id="password"
-            v-model="registerForm.password"
-            required
-            placeholder="비밀번호를 입력하세요"
-          />
-        </div>
-
-        <div class="form-group">
-          <label for="passwordConfirm">비밀번호 확인</label>
-          <input
-            type="password"
-            id="passwordConfirm"
-            v-model="passwordConfirm"
-            required
-            placeholder="비밀번호를 다시 입력하세요"
-          />
-          <span class="password-match" :class="{ 'not-match': !isPasswordMatch && passwordConfirm }">
-            {{ passwordMatchMessage }}
-          </span>
-        </div>
-
-        <div class="form-group">
-          <label for="email">이메일</label>
-          <input
-            type="email"
-            id="email"
-            v-model="registerForm.email"
-            required
-            placeholder="이메일을 입력하세요"
-          />
-        </div>
-
-        <div class="form-group">
-          <label for="address">주소</label>
-          <input
+            <label for="address">주소</label>
+            <input
             type="text"
             id="address"
             v-model="registerForm.address"

--- a/final/Frontend/final-front/src/views/RegisterView.vue
+++ b/final/Frontend/final-front/src/views/RegisterView.vue
@@ -1,0 +1,271 @@
+<template>
+  <div class="register-container">
+    <div class="register-box">
+      <h2>회원가입</h2>
+      <form @submit.prevent="handleRegister" class="register-form">
+        <div class="form-group">
+          <label for="name">이름</label>
+          <input
+            type="text"
+            id="name"
+            v-model="registerForm.name"
+            required
+            placeholder="이름을 입력하세요"
+          />
+        </div>
+        
+        <div class="form-group">
+          <label for="password">비밀번호</label>
+          <input
+            type="password"
+            id="password"
+            v-model="registerForm.password"
+            required
+            placeholder="비밀번호를 입력하세요"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="passwordConfirm">비밀번호 확인</label>
+          <input
+            type="password"
+            id="passwordConfirm"
+            v-model="passwordConfirm"
+            required
+            placeholder="비밀번호를 다시 입력하세요"
+          />
+          <span class="password-match" :class="{ 'not-match': !isPasswordMatch && passwordConfirm }">
+            {{ passwordMatchMessage }}
+          </span>
+        </div>
+
+        <div class="form-group">
+          <label for="email">이메일</label>
+          <input
+            type="email"
+            id="email"
+            v-model="registerForm.email"
+            required
+            placeholder="이메일을 입력하세요"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="address">주소</label>
+          <input
+            type="text"
+            id="address"
+            v-model="registerForm.address"
+            required
+            placeholder="주소를 입력하세요"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="number">전화번호</label>
+          <input
+            type="tel"
+            id="number"
+            v-model="registerForm.number"
+            required
+            maxlength="11"
+            placeholder="01012345678"
+            @input="validatePhoneNumber"
+          />
+          <span class="input-guide" v-if="!isValidPhoneNumber">
+            올바른 전화번호 형식이 아닙니다. (예: 01012345678)
+          </span>
+        </div>
+
+        <button type="submit" class="register-button" :disabled="!isFormValid">회원가입</button>
+      </form>
+      <div class="login-link">
+        이미 계정이 있으신가요? <router-link to="/login">로그인</router-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const passwordConfirm = ref('')
+
+const registerForm = reactive({
+  name: '',
+  password: '',
+  email: '',
+  address: '',
+  number: '',
+  role: 'USER' // 기본 역할 설정
+})
+
+const isPasswordMatch = computed(() => {
+  return !passwordConfirm.value || registerForm.password === passwordConfirm.value
+})
+
+const passwordMatchMessage = computed(() => {
+  if (!passwordConfirm.value) return ''
+  return isPasswordMatch.value ? '비밀번호가 일치합니다.' : '비밀번호가 일치하지 않습니다.'
+})
+
+const validatePhoneNumber = (event) => {
+  // 숫자만 입력 가능하도록
+  registerForm.number = event.target.value.replace(/[^0-9]/g, '').slice(0, 11)
+}
+
+const isValidPhoneNumber = computed(() => {
+  const phoneRegex = /^010\d{8}$/
+  return !registerForm.number || phoneRegex.test(registerForm.number)
+})
+
+const getFormattedPhoneNumber = () => {
+  // 서버 전송을 위한 포맷팅
+  const num = registerForm.number
+  if (num.length === 11) {
+    return `${num.slice(0, 3)}-${num.slice(3, 7)}-${num.slice(7)}`
+  }
+  return num
+}
+
+const isFormValid = computed(() => {
+  return registerForm.name &&
+         registerForm.password &&
+         passwordConfirm.value &&
+         registerForm.password === passwordConfirm.value &&
+         registerForm.email &&
+         registerForm.address &&
+         registerForm.number &&
+         isValidPhoneNumber.value
+})
+
+const handleRegister = async () => {
+  try {
+    if (registerForm.password !== passwordConfirm.value) {
+      alert('비밀번호가 일치하지 않습니다.')
+      return
+    }
+
+    // 서버로 전송할 데이터 준비
+    const formData = {
+      ...registerForm,
+      number: getFormattedPhoneNumber() // 전화번호 포맷팅
+    }
+
+    // TODO: API 호출 구현
+    console.log('회원가입 시도:', formData)
+    router.push('/login')
+  } catch (error) {
+    console.error('회원가입 실패:', error)
+  }
+}
+</script>
+
+<style scoped>
+.register-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 70px);
+  background-color: #f5f6f8;
+  padding: 20px;
+}
+
+.register-box {
+  background: white;
+  padding: 40px;
+  border-radius: 10px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 500px;
+}
+
+.register-box h2 {
+  text-align: center;
+  color: #333;
+  margin-bottom: 30px;
+  font-weight: 600;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 8px;
+  color: #333;
+  font-weight: 500;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+.form-group input:focus {
+  border-color: #2ecc71;
+  outline: none;
+}
+
+.register-button {
+  width: 100%;
+  padding: 12px;
+  background-color: #2ecc71;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.register-button:hover {
+  background-color: #27ae60;
+}
+
+.register-button:disabled {
+  background-color: #95a5a6;
+  cursor: not-allowed;
+}
+
+.login-link {
+  text-align: center;
+  margin-top: 20px;
+  color: #666;
+}
+
+.login-link a {
+  color: #2ecc71;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.login-link a:hover {
+  text-decoration: underline;
+}
+
+.password-match {
+  display: block;
+  margin-top: 5px;
+  font-size: 14px;
+  color: #27ae60;
+}
+
+.password-match.not-match {
+  color: #e74c3c;
+}
+
+.input-guide {
+  display: block;
+  margin-top: 5px;
+  font-size: 14px;
+  color: #e74c3c;
+}
+</style>


### PR DESCRIPTION
## **📌 Summary**

> 프론트의 register page를 구현 했습니다.
> 
> 
> 

---

## **✅ Changes**

- [x]  Feature: register view 추가

**Details:**

- 회원가입 뷰 추가 및 라우터로 연결
---

## **🔗 Related Issue**

> Closes #6 
> 

---

## **💬 Additional Notes**

> 1. 회원가입시 실제 API가 전송되는게 아닙니다. 
> 실제 백엔드 구현 시 프론트도 같이 구현해주세요!
> 2. 이메일 기반으로 유저 중복체크도 해줘야 할 것 같아요! 
> 비동기로 중복체크 버튼도 추후에 추가해야 할 듯?