### PR TITLE
Feat/#21 jw tlogin

### DIFF
--- a/final/Backend/build.gradle
+++ b/final/Backend/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 처리를 위해 jackson 모듈 필요
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/final/Backend/src/main/java/com/example/demo/controller/AuthController.java
+++ b/final/Backend/src/main/java/com/example/demo/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.dto.User.LoginRequestDto;
+import com.example.demo.model.dto.User.UserResponseDto;
+import com.example.demo.security.JwtProvider;
+import com.example.demo.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequestDto request) {
+        UserResponseDto user = userService.login(request.getEmail(), request.getPassword());
+        String token = jwtProvider.createToken(user.getId().toString());
+
+        return ResponseEntity.ok(Map.of(
+                "Authorization", "Bearer " + token,
+                "userId", user.getId()
+        ));
+    }
+
+}

--- a/final/Backend/src/main/java/com/example/demo/model/dto/User/LoginRequestDto.java
+++ b/final/Backend/src/main/java/com/example/demo/model/dto/User/LoginRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.demo.model.dto.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginRequestDto {
+    private String email;
+    private String password;
+}

--- a/final/Backend/src/main/java/com/example/demo/security/JwtAuthenticationFilter.java
+++ b/final/Backend/src/main/java/com/example/demo/security/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.example.demo.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        String token = null;
+
+        if (header != null && header.startsWith("Bearer ")) {
+            token = header.substring(7); // "Bearer " 이후의 JWT만 추출
+        }
+
+        try {
+            if (token != null && jwtProvider.validateToken(token)) {
+                String userId = jwtProvider.getUserId(token);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(userId, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+            filterChain.doFilter(request, response);
+        } catch (RuntimeException e) {
+            if ("TOKEN_EXPIRED".equals(e.getMessage())) {
+                // 토큰 만료 시 401에러와 TOKEN_EXPIRED 코드 응답 생성
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+                response.setContentType("application/json");
+                response.getWriter().write("{\"code\":\"TOKEN_EXPIRED\",\"message\":\"토큰이 만료되었습니다\"}");
+            } else {
+                // 다른 예외는 그대로 전달
+                throw e;
+            }
+        }
+    }
+}

--- a/final/Backend/src/main/java/com/example/demo/security/JwtProvider.java
+++ b/final/Backend/src/main/java/com/example/demo/security/JwtProvider.java
@@ -1,0 +1,69 @@
+package com.example.demo.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKeyString;
+
+    private Key secretKey;
+
+    private final long EXPIRATION = 60 * 60 * 1000L; // 1시간
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createToken(String userId) {
+        Claims claims = Jwts.claims()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION));
+
+//        나중에 이런식으로 jwt에 추가로 이것저것 넣을수있음.
+//        claims.put("role",userrole);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .signWith(secretKey,SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰인 경우 특별히 처리
+            throw new RuntimeException("TOKEN_EXPIRED");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String getUserId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/final/Backend/src/main/java/com/example/demo/security/SecurityConfig.java
+++ b/final/Backend/src/main/java/com/example/demo/security/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.example.demo.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**","/api/users").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/final/Backend/src/main/java/com/example/demo/service/UserService.java
+++ b/final/Backend/src/main/java/com/example/demo/service/UserService.java
@@ -10,6 +10,8 @@ import com.example.demo.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -22,5 +24,14 @@ public class UserService {
         }
         User user = dto.toEntity();
         return userRepository.save(user).getId();
+    }
+
+    public UserResponseDto login(String email, String password) {
+        Optional<User> user = userRepository.findByEmailAndPassword(email, password);
+        if(user.isEmpty()) {
+            throw new IllegalArgumentException("가입된 이메일이 없습니다.");
+        }
+
+        return UserResponseDto.from(user.get());
     }
 }

--- a/final/Backend/src/main/resources/application-local.properties
+++ b/final/Backend/src/main/resources/application-local.properties
@@ -19,3 +19,5 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 spring.web.resources.static-locations=classpath:/static/
 spring.mvc.static-path-pattern=/static/**
+
+jwt.secret=AbCDEfGhIJKLmNoPQRstuVWXYZ12345678

--- a/final/Backend/src/main/resources/application-prod.properties
+++ b/final/Backend/src/main/resources/application-prod.properties
@@ -17,3 +17,5 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 spring.web.resources.static-locations=classpath:/static/
 spring.mvc.static-path-pattern=/static/**
+
+jwt.secret=AbCDEfGhIJKLmNoPQRstuVWXYZ12345678

--- a/final/Frontend/final-front/src/components/TheHeader.vue
+++ b/final/Frontend/final-front/src/components/TheHeader.vue
@@ -13,14 +13,49 @@
         </nav>
       </div>
       <div class="header-right">
-        <router-link to="/login" class="auth-btn login-btn">로그인</router-link>
-        <router-link to="/register" class="auth-btn register-btn">회원가입</router-link>
+        <template v-if="isLoggedIn">
+          <router-link to="/mypage" class="auth-btn mypage-btn">마이페이지</router-link>
+          <button @click="handleLogout" class="auth-btn logout-btn">로그아웃</button>
+        </template>
+        <template v-else>
+          <router-link to="/login" class="auth-btn login-btn">로그인</router-link>
+          <router-link to="/register" class="auth-btn register-btn">회원가입</router-link>
+        </template>
       </div>
     </div>
   </header>
 </template>
 
 <script setup>
+import { ref, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const isLoggedIn = ref(false)
+
+const checkLoginStatus = () => {
+  const token = sessionStorage.getItem('token')
+  console.log('현재 토큰:', token) // 토큰 확인용
+  isLoggedIn.value = !!token
+}
+
+// 컴포넌트 마운트 시 로그인 상태 확인
+onMounted(() => {
+  checkLoginStatus()
+})
+
+// 라우트 변경 시마다 로그인 상태 확인
+watch(() => router.currentRoute.value, () => {
+  checkLoginStatus()
+})
+
+const handleLogout = () => {
+  sessionStorage.removeItem('token')
+  sessionStorage.removeItem('userId')
+  isLoggedIn.value = false
+  router.push('/login')
+}
+
 defineOptions({
   name: 'TheHeader'
 })
@@ -131,5 +166,26 @@ defineOptions({
 
 .register-btn:hover {
   background-color: #27ae60;
+}
+
+.mypage-btn {
+  background-color: #3498db;
+  color: white;
+  border: none;
+}
+
+.mypage-btn:hover {
+  background-color: #2980b9;
+}
+
+.logout-btn {
+  background-color: #e74c3c;
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+.logout-btn:hover {
+  background-color: #c0392b;
 }
 </style>

--- a/final/Frontend/final-front/src/utils/axios.js
+++ b/final/Frontend/final-front/src/utils/axios.js
@@ -1,0 +1,46 @@
+import axios from 'axios'
+import router from '@/router'
+
+const api = axios.create({
+  baseURL: 'http://localhost:8080/api'
+})
+
+// 요청 인터셉터
+api.interceptors.request.use(
+  config => {
+    const token = sessionStorage.getItem('token')
+    if (token) {
+      config.headers.Authorization = token
+    }
+    return config
+  },
+  error => {
+    return Promise.reject(error)
+  }
+)
+
+// 응답 인터셉터
+api.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response && error.response.status === 401) {
+      // 토큰 만료 코드 확인 (서버에서 보내는 특정 코드)
+      const errorData = error.response.data
+      const isTokenExpired = errorData && errorData.code === 'TOKEN_EXPIRED'
+      
+      // 토큰이 만료되었거나 유효하지 않은 경우
+      sessionStorage.removeItem('token')
+      sessionStorage.removeItem('userId')
+      router.push('/login')
+      
+      if (isTokenExpired) {
+        alert('로그인 세션이 만료되었습니다. 다시 로그인해주세요.')
+      } else {
+        alert('로그인이 필요한 서비스입니다.')
+      }
+    }
+    return Promise.reject(error)
+  }
+)
+
+export default api

--- a/final/Frontend/final-front/src/views/LoginView.vue
+++ b/final/Frontend/final-front/src/views/LoginView.vue
@@ -4,13 +4,13 @@
       <h2>로그인</h2>
       <form @submit.prevent="handleLogin" class="login-form">
         <div class="form-group">
-          <label for="userId">아이디</label>
+          <label for="email">이메일</label>
           <input
-            type="text"
-            id="userId"
-            v-model="loginForm.userId"
+            type="email"
+            id="email"
+            v-model="loginForm.email"
             required
-            placeholder="아이디를 입력하세요"
+            placeholder="이메일을 입력하세요"
           />
         </div>
         <div class="form-group">
@@ -46,23 +46,47 @@
 <script setup>
 import { reactive } from 'vue'
 import { useRouter } from 'vue-router'
+import axios from 'axios'
 
 const router = useRouter()
 
 const loginForm = reactive({
-  userId: '',
-  password: '',
-  rememberMe: false
+  email: '',    // userId를 email로 변경
+  password: ''
 })
 
 const handleLogin = async () => {
   try {
-    // TODO: API 호출 구현
-    console.log('로그인 시도:', loginForm)
-    // 로그인 성공 시 홈으로 이동
-    router.push('/')
+    const response = await axios.post('http://localhost:8080/api/auth/login', {
+      email: loginForm.email,
+      password: loginForm.password
+    })
+
+    console.log('로그인 응답:', response.data) // 응답 데이터 확인용
+
+    // response.data에서 직접 값을 가져옴
+    const token = response.data.Authorization
+    const userId = response.data.userId
+
+    if (token && userId) {
+      sessionStorage.setItem('token', token)
+      sessionStorage.setItem('userId', userId)
+      
+      console.log('저장된 토큰:', sessionStorage.getItem('token')) // 저장 확인용
+      console.log('저장된 userId:', sessionStorage.getItem('userId'))
+      
+      router.push('/')
+    } else {
+      throw new Error('로그인 응답 데이터가 올바르지 않습니다.')
+    }
   } catch (error) {
     console.error('로그인 실패:', error)
+    if (error.response) {
+      console.error('에러 응답:', error.response.data)
+      alert('로그인에 실패했습니다.')
+    } else {
+      alert(error.message)
+    }
   }
 }
 </script>


### PR DESCRIPTION
## **📌 Summary**

> JWT의 access 토큰을 통해 유저의 로그인을 관리 합니다.
> 스프링 시큐리티의 필터를 조정합니다.
> vue에서 로그인시 jwt 토큰을 세선 스토리지에 저장합니다.
> 
> 

---

## **✅ Changes**

- [x]  Feature: 스프링 시큐리티 필터 추가
- [x]  Feature: jwt 토큰 provider와 필터 추가
- [x]  Feature: auth 컨트롤러에 로그인 추가
- [x]  Feature: 로그인 뷰에 로그인 API 연결
- [x]  Feature: 헤더 컴포넌트에 마이페이지, 로그아웃 추가
- [x]  Feature: API요청시 토큰값을 관리하는 axios.js 추가

**Details:**

프론트에서 로그인 요청시 올바른 이메일과 패스워드를 가진 유저로 요청이 온다면

백엔드에서는 jwt토큰을 발행하여 헤더에 Authorization 에 토큰을 담아서 보낸다.

프론트에서는 헤더에 있는 jwt 토큰을 세션 스토리지에 저장하여 서버에 API를 요청할때마다 헤더에 jwt 토큰을 같이보낸다.

만약 API를 요청했을때 시간이 만료되어 유효하지않은 토큰이라면 세션스토리지의 값을 제거한다(로그아웃의 효과를 지님)

---

## **🔗 Related Issue**

> Close #21 
> 

---

## **💬 Additional Notes**

> 1. 추후에는 토큰만료와 같은 예외 발생시 커스텀 예외를 만들어서 관리하는 것도 좋을듯합니다.
> 2. objectMapper를 쓰면 좀 더 response를 잘 만들 수 있을지도..?
>