### PR TITLE
<fix> : jwt, spring security까지 통합해서 테스트 수정

### DIFF
--- a/final/Backend/src/main/java/com/example/demo/controller/BoardController.java
+++ b/final/Backend/src/main/java/com/example/demo/controller/BoardController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,6 +28,7 @@ public class BoardController {
         return ResponseEntity.ok(boardService.getAllBoardSummaries(page));
     }
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping
     public ResponseEntity<BoardResponseDto> boardPost(@RequestBody @Valid BoardRequestDto dto,@AuthenticationPrincipal String userId) {//jwt 토큰 내부의 user id를 받아올 방법 필요
         return ResponseEntity.ok(boardService.saveBoard(dto,Integer.valueOf(userId)));
@@ -36,10 +38,11 @@ public class BoardController {
     public ResponseEntity<Map<String, Object>> boardDetail(@PathVariable Integer boardId, @AuthenticationPrincipal String userId) {
         Map<String, Object> response = new HashMap<>();
         response.put("board",boardService.getBoardDetail(boardId));
-        response.put("userId",Integer.valueOf(userId));
+        if(userId!=null && !userId.equals("anonymousUser")) response.put("userId",Integer.valueOf(userId));
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("isAuthenticated()")
     @DeleteMapping("/{boardId}")
     public ResponseEntity<?> boardDelete(@PathVariable Integer boardId) {
         boardService.deleteBoard(boardId);

--- a/final/Backend/src/main/java/com/example/demo/controller/TripPlanController.java
+++ b/final/Backend/src/main/java/com/example/demo/controller/TripPlanController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,13 +22,13 @@ public class TripPlanController {
     private final TripPlanService tripPlanService;
     //jwt token에서  user id 파싱 필요
     @GetMapping
-    public ResponseEntity<Page<TripPlanSummaryDto>> planSummary(Integer userId, @RequestParam(defaultValue = "0") int page) {
-        return ResponseEntity.ok(tripPlanService.getUserTripPlans(userId, page));
+    public ResponseEntity<Page<TripPlanSummaryDto>> planSummary(@AuthenticationPrincipal String userId, @RequestParam(defaultValue = "0") int page) {
+        return ResponseEntity.ok(tripPlanService.getUserTripPlans(Integer.valueOf(userId), page));
     }
 
     @PostMapping
-    public ResponseEntity<TripPlanService.TripPlanWithSnippetsDto> planPost(@RequestBody @Valid TripPlanRequestDto dto, Integer userId) {
-        return ResponseEntity.ok(tripPlanService.saveTripPlan(dto, userId));
+    public ResponseEntity<TripPlanService.TripPlanWithSnippetsDto> planPost(@RequestBody @Valid TripPlanRequestDto dto, @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(tripPlanService.saveTripPlan(dto, Integer.valueOf(userId)));
     }
 
     @PutMapping("/{planId}")

--- a/final/Backend/src/main/java/com/example/demo/security/SecurityConfig.java
+++ b/final/Backend/src/main/java/com/example/demo/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -13,6 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -26,7 +28,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**","/users").permitAll()
+                        .requestMatchers("/auth/**","/users","/boards","/boards/{boardId}", "/attractions/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/final/Backend/src/test/java/com/example/demo/integration/AttractionControllerIntegrationTest.java
+++ b/final/Backend/src/test/java/com/example/demo/integration/AttractionControllerIntegrationTest.java
@@ -24,7 +24,7 @@ import com.example.demo.repository.AttractionRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@AutoConfigureMockMvc(addFilters = false)  // Spring Security 필터 비활성화
+@AutoConfigureMockMvc
 //@Transactional
 public class AttractionControllerIntegrationTest {
 

--- a/final/Backend/src/test/java/com/example/demo/integration/UserControllerIntegrationTest.java
+++ b/final/Backend/src/test/java/com/example/demo/integration/UserControllerIntegrationTest.java
@@ -16,6 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -83,14 +86,17 @@ public class UserControllerIntegrationTest {
 
     @Test
     void updateUser_updatesExistingUser() throws Exception {
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("name", "수정된 사용자");
-        params.add("address", "수정된 주소");
-        params.add("number", "010-1111-2222");
+        Map<String, String> boardRequest = new HashMap<>();
+        boardRequest.put("name", "수정된 사용자");
+        boardRequest.put("address", "수정된 주소");
+        boardRequest.put("number", "010-1111-2222");
+        // ObjectMapper를 사용하여 JSON 문자열로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBody = objectMapper.writeValueAsString(boardRequest);
 
         mockMvc.perform(put("/users/{userId}", testUser.getId())
-                .params(params)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .content(requestBody)
+                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name", is("수정된 사용자")))
                 .andExpect(jsonPath("$.address", is("수정된 주소")))

--- a/final/Backend/src/test/java/com/example/demo/service/BoardServiceTest.java
+++ b/final/Backend/src/test/java/com/example/demo/service/BoardServiceTest.java
@@ -30,9 +30,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -226,7 +224,8 @@ public class BoardServiceTest {
         Board resBoard=new Board();
         resBoard.setTitle("새 게시글");
         resBoard.setContent("새 내용");
-
+        resBoard.setUser(testUser);
+        resBoard.setHit(0); resBoard.setCreatedAt(LocalDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
         when(boardRepository.save(any(Board.class))).thenReturn(resBoard);
@@ -236,7 +235,11 @@ public class BoardServiceTest {
 
         // then
         assertThat(result).isNotNull();
-        verify(boardRepository, times(1)).save(resBoard);
+        verify(boardRepository, times(1)).save(argThat(saveBoard ->
+                "새 게시글".equals(saveBoard.getTitle()) &&
+                "새 내용".equals(saveBoard.getContent()) &&
+                        saveBoard.getHit() == 0 &&
+                        saveBoard.getCreatedAt() != null));
         verify(userRepository, times(1)).findById(userId);
     }
 


### PR DESCRIPTION
## **📌 Summary**

> 기존 테스트에 security, jwt 기능 추가해서 수정
> 기존 컨트롤러를 인증 필요 여부 따라 수정


---

## **✅ Changes**

- [x]  Feature: github action test를 통과할 수 있게 기존 테스트들을 security까지 통합하여 수정
- [x]  Feature: 기존 컨트롤러를 인증 필요 여부에 따라 url 별, 메서드 별 인증 처리 구분 

**Details:**

- @EnableMethodSecurity 추가로 메서드 단위로 인증 처리가 가능하게 됬습니다

---

## **🔗 Related Issue**

> Closes #27 

---
